### PR TITLE
Spotify changed the way they fetch data recently; updated script to fix.

### DIFF
--- a/spotify_remove_podcasts.sh
+++ b/spotify_remove_podcasts.sh
@@ -29,6 +29,6 @@ fi
 
 # Actually do the thing!
 cd "$target/current/active/files/extra/share/spotify/Apps"
-unzip -p xpui.spa xpui.js | sed 's/,show,/,/' | sed 's/,episode"/"/' > xpui.js
+unzip -p xpui.spa xpui.js | sed 's/withQueryParameters(e){return this.queryParameters=e,this}/withQueryParameters(e){return this.queryParameters=(e.types?{...e, types: e.types.split(",").filter(_ => !["episode","show"].includes(_)).join(",")}:e),this}/' > xpui.js
 cp xpui.spa xpui.spa.bak
 zip xpui.spa xpui.js


### PR DESCRIPTION
Apparently they did this for the macOS version in February 2022. Not surprising it took four months for the change to reach Linux users. The fix's original author has the updated fix here: https://remysharp.com/2021/08/17/removing-shows-from-spotify

Merging this will fix #2.